### PR TITLE
Rr/add cmake build and provide handle to platform dependent function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(DS1307_INCLUDE src CACHE INTERNAL "" FORCE)
+file(GLOB_RECURSE DS1307_SOURCES src/*.c)
+
+include_directories(${DS1307_INCLUDE})
+add_library(ds1307 STATIC ${DS1307_SOURCES})
+target_include_directories(ds1307 SYSTEM PUBLIC ${DS1307_INCLUDE})

--- a/src/driver_ds1307.c
+++ b/src/driver_ds1307.c
@@ -68,7 +68,7 @@
 
 /**
  * @brief     write one byte
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] reg is the iic register address
  * @param[in] data is the write data
  * @return    status code
@@ -76,21 +76,21 @@
  *            - 1 write failed
  * @note      none
  */
-static uint8_t a_ds1307_iic_write(ds1307_handle_t *handle, uint8_t reg, uint8_t data)
+static uint8_t a_ds1307_iic_write(ds1307_handle_t handle, uint8_t reg, uint8_t data)
 {
-    if (handle->iic_write(DS1307_ADDRESS, reg, &data, 1) != 0)        /* write data */
+    if (handle->iic_write(handle, DS1307_ADDRESS, reg, &data, 1) != 0)      /* write data */
     {
-        return 1;                                                     /* return error */
+        return 1;                                                           /* return error */
     }
     else
     {
-        return 0;                                                     /* success return 0 */
+        return 0;                                                           /* success return 0 */
     }
 }
 
 /**
  * @brief     write multiple bytes
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] reg is the iic register address
  * @param[in] *buf points to a data buffer
  * @param[in] len is the data buffer length
@@ -99,21 +99,21 @@ static uint8_t a_ds1307_iic_write(ds1307_handle_t *handle, uint8_t reg, uint8_t 
  *            - 1 write failed
  * @note      none
  */
-static uint8_t a_ds1307_iic_multiple_write(ds1307_handle_t *handle, uint8_t reg, uint8_t *buf, uint8_t len)
+static uint8_t a_ds1307_iic_multiple_write(ds1307_handle_t handle, uint8_t reg, uint8_t *buf, uint8_t len)
 {
-    if (handle->iic_write(DS1307_ADDRESS, reg, buf, len) != 0)       /* write data */
+    if (handle->iic_write(handle, DS1307_ADDRESS, reg, buf, len) != 0)      /* write data */
     {
-        return 1;                                                    /* return error */
+        return 1;                                                           /* return error */
     }
     else
-    {                                                                /* success return 0 */
+    {                                                                       /* success return 0 */
         return 0;
     }
 }
 
 /**
  * @brief      read multiple bytes
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[in]  reg is the iic register address
  * @param[out] *buf points to a data buffer
  * @param[in]  len is the data buffer length
@@ -122,14 +122,14 @@ static uint8_t a_ds1307_iic_multiple_write(ds1307_handle_t *handle, uint8_t reg,
  *             - 1 read failed
  * @note       none
  */
-static uint8_t a_ds1307_iic_multiple_read(ds1307_handle_t *handle, uint8_t reg, uint8_t *buf, uint8_t len)
+static uint8_t a_ds1307_iic_multiple_read(ds1307_handle_t handle, uint8_t reg, uint8_t *buf, uint8_t len)
 {
-    if (handle->iic_read(DS1307_ADDRESS, reg, buf, len) != 0)        /* read data */
+    if (handle->iic_read(handle, DS1307_ADDRESS, reg, buf, len) != 0)       /* read data */
     {
-        return 1;                                                    /* return error */
+        return 1;                                                           /* return error */
     }
     else
-    {                                                                /* success return 0 */
+    {                                                                       /* success return 0 */
         return 0;
     }
 }
@@ -171,7 +171,7 @@ static uint8_t a_ds1307_bcd2hex(uint8_t val)
 
 /**
  * @brief     set the current time
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] *t points to a time structure
  * @return    status code
  *            - 0 success
@@ -181,7 +181,7 @@ static uint8_t a_ds1307_bcd2hex(uint8_t val)
  *            - 4 time is invalid
  * @note      none
  */
-uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
+uint8_t ds1307_set_time(ds1307_handle_t handle, ds1307_time_t *t)
 {
     uint8_t res;
     uint8_t reg;
@@ -197,7 +197,7 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
     }
     if (t == NULL)                                                                                           /* check time */
     {
-        handle->debug_print("ds1307: time is null.\n");                                                      /* time is null */
+        handle->debug_print(handle, "ds1307: time is null.\n");                                              /* time is null */
         
         return 2;                                                                                            /* return error */
     }
@@ -205,43 +205,43 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
     {
         if ((t->year < 2000) || (t->year > 2100))                                                            /* check year */
         {
-            handle->debug_print("ds1307: year can't be over 2100 or less than 2000.\n");                     /* year can't be over 2100 or less than 2000 */
+            handle->debug_print(handle, "ds1307: year can't be over 2100 or less than 2000.\n");             /* year can't be over 2100 or less than 2000 */
             
             return 4;                                                                                        /* return error */
         }
         if ((t->month == 0) || (t->month > 12))                                                              /* check month */
         {
-            handle->debug_print("ds1307: month can't be zero or over than 12.\n");                           /* month can't be zero or over than 12 */
+            handle->debug_print(handle, "ds1307: month can't be zero or over than 12.\n");                   /* month can't be zero or over than 12 */
             
             return 4;                                                                                        /* return error */
         }
         if ((t->week == 0) || (t->week > 7))                                                                 /* check week */
         {
-            handle->debug_print("ds1307: week can't be zero or over than 7.\n");                             /* week can't be zero or over than 7 */
+            handle->debug_print(handle, "ds1307: week can't be zero or over than 7.\n");                     /* week can't be zero or over than 7 */
             
             return 4;                                                                                        /* return error */
         }
         if ((t->date == 0) || (t->date > 31))                                                                /* check data */
         {
-            handle->debug_print("ds1307: date can't be zero or over than 31.\n");                            /* date can't be zero or over than 31 */
+            handle->debug_print(handle, "ds1307: date can't be zero or over than 31.\n");                    /* date can't be zero or over than 31 */
             
             return 4;                                                                                        /* return error */
         }
         if ((t->hour < 1) || (t->hour > 12))                                                                 /* check hour */
         {
-            handle->debug_print("ds1307: hour can't be over than 12 or less 1.\n");                          /* hour can't be over than 12 or less 1 */
+            handle->debug_print(handle, "ds1307: hour can't be over than 12 or less 1.\n");                  /* hour can't be over than 12 or less 1 */
             
             return 4;                                                                                        /* return error */
         }
         if (t->minute > 59)                                                                                  /* check minute */
         {
-            handle->debug_print("ds1307: minute can't be over than 59.\n");                                  /* minute can't be over than 59 */
+            handle->debug_print(handle, "ds1307: minute can't be over than 59.\n");                          /* minute can't be over than 59 */
             
             return 4;                                                                                        /* return error */
         }
         if (t->second > 59)                                                                                  /* check second */
         {
-            handle->debug_print("ds1307: second can't be over than 59.\n");                                  /* second can't be over than 59 */
+            handle->debug_print(handle, "ds1307: second can't be over than 59.\n");                          /* second can't be over than 59 */
             
             return 4;                                                                                        /* return error */
         }
@@ -250,50 +250,50 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
     {
         if ((t->year < 2000) || (t->year > 2100))                                                            /* check year */
         {
-            handle->debug_print("ds1307: year can't be over 2100 or less than 2000.\n");                     /* year can't be over 2100 or less than 2000 */
+            handle->debug_print(handle, "ds1307: year can't be over 2100 or less than 2000.\n");             /* year can't be over 2100 or less than 2000 */
             
             return 4;                                                                                        /* return error */
         }
         if ((t->month == 0) || (t->month > 12))                                                              /* check month */
         {
-            handle->debug_print("ds1307: month can't be zero or over than 12.\n");                           /* month can't be zero or over than 12 */
+            handle->debug_print(handle, "ds1307: month can't be zero or over than 12.\n");                   /* month can't be zero or over than 12 */
             
             return 4;                                                                                        /* return error */
         }
         if ((t->week == 0) || (t->week > 7))                                                                 /* check week */
         {
-            handle->debug_print("ds1307: week can't be zero or over than 7.\n");                             /* week can't be zero or over than 7 */
+            handle->debug_print(handle, "ds1307: week can't be zero or over than 7.\n");                     /* week can't be zero or over than 7 */
             
             return 4;                                                                                        /* return error */
         }
         if ((t->date == 0) || (t->date > 31))                                                                /* check data */
         {
-            handle->debug_print("ds1307: date can't be zero or over than 31.\n");                            /* date can't be zero or over than 31 */
+            handle->debug_print(handle, "ds1307: date can't be zero or over than 31.\n");                    /* date can't be zero or over than 31 */
             
             return 4;                                                                                        /* return error */
         }
         if (t->hour > 23)                                                                                    /* check hour */
         {
-            handle->debug_print("ds1307: hour can't be over than 23.\n");                                    /* hour can't be over than 23 */
+            handle->debug_print(handle, "ds1307: hour can't be over than 23.\n");                            /* hour can't be over than 23 */
             
             return 4;                                                                                        /* return error */
         }
         if (t->minute > 59)                                                                                  /* check minute */
         {
-            handle->debug_print("ds1307: minute can't be over than 59.\n");                                  /* minute can't be over than 59 */
+            handle->debug_print(handle, "ds1307: minute can't be over than 59.\n");                          /* minute can't be over than 59 */
             
             return 4;                                                                                        /* return error */
         }
         if (t->second > 59)                                                                                  /* check second */
         {
-            handle->debug_print("ds1307: second can't be over than 59.\n");                                  /* second can't be over than 59 */
+            handle->debug_print(handle, "ds1307: second can't be over than 59.\n");                          /* second can't be over than 59 */
             
             return 4;                                                                                        /* return error */
         }
     }
     else
     {
-        handle->debug_print("ds1307: format is invalid.\n");                                                 /* format is invalid */
+        handle->debug_print(handle, "ds1307: format is invalid.\n");                                         /* format is invalid */
         
         return 4;                                                                                            /* return error */
     }
@@ -301,21 +301,21 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_SECOND, &reg, 1);                                    /* read second */
     if (res != 0)                                                                                            /* check result */
     {
-        handle->debug_print("ds1307: read second failed.\n");                                                /* read second failed */
+        handle->debug_print(handle, "ds1307: read second failed.\n");                                        /* read second failed */
         
         return 1;                                                                                            /* return error */
     }
     res = a_ds1307_iic_write(handle, DS1307_REG_SECOND, a_ds1307_hex2bcd(t->second) | (reg & (1 << 7)));     /* write second */
     if (res != 0)                                                                                            /* check result */
     {
-        handle->debug_print("ds1307: write second failed.\n");                                               /* write second failed */
+        handle->debug_print(handle, "ds1307: write second failed.\n");                                       /* write second failed */
         
         return 1;                                                                                            /* return error */
     }
     res = a_ds1307_iic_write(handle, DS1307_REG_MINUTE, a_ds1307_hex2bcd(t->minute));                        /* write minute */
     if (res != 0)                                                                                            /* check result */
     {
-        handle->debug_print("ds1307: write minute failed.\n");                                               /* write minute failed */
+        handle->debug_print(handle, "ds1307: write minute failed.\n");                                       /* write minute failed */
         
         return 1;                                                                                            /* return error */
     }
@@ -330,28 +330,28 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
     res = a_ds1307_iic_write(handle, DS1307_REG_HOUR, reg);                                                  /* write hour */
     if (res != 0)                                                                                            /* check result */
     {
-        handle->debug_print("ds1307: write hour failed.\n");                                                 /* write hour failed */
+        handle->debug_print(handle, "ds1307: write hour failed.\n");                                         /* write hour failed */
         
         return 1;                                                                                            /* return error */
     }
     res = a_ds1307_iic_write(handle, DS1307_REG_WEEK, a_ds1307_hex2bcd(t->week));                            /* write week */
     if (res != 0)                                                                                            /* check result */
     {
-        handle->debug_print("ds1307: write week failed.\n");                                                 /* write week failed */
+        handle->debug_print(handle, "ds1307: write week failed.\n");                                         /* write week failed */
         
         return 1;                                                                                            /* return error */
     }
     res = a_ds1307_iic_write(handle, DS1307_REG_DATE, a_ds1307_hex2bcd(t->date));                            /* write data */
     if (res != 0)                                                                                            /* check result */
     {
-        handle->debug_print("ds1307: write date failed.\n");                                                 /* write date failed */
+        handle->debug_print(handle, "ds1307: write date failed.\n");                                         /* write date failed */
         
         return 1;                                                                                            /* return error */
     }
     res = a_ds1307_iic_write(handle, DS1307_REG_MONTH, a_ds1307_hex2bcd(t->month));                          /* write month and century */
     if (res != 0)                                                                                            /* check result */
     {
-        handle->debug_print("ds1307: write century and month failed.\n");                                    /* write century and month failed */
+        handle->debug_print(handle, "ds1307: write century and month failed.\n");                            /* write century and month failed */
         
         return 1;                                                                                            /* return error */
     }
@@ -359,7 +359,7 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
     res = a_ds1307_iic_write(handle, DS1307_REG_YEAR, a_ds1307_hex2bcd((uint8_t)year));                      /* write year */
     if (res != 0)                                                                                            /* check result */
     {
-        handle->debug_print("ds1307: write year failed.\n");                                                 /* write year failed */
+        handle->debug_print(handle, "ds1307: write year failed.\n");                                         /* write year failed */
         
         return 1;                                                                                            /* return error */
     }
@@ -369,7 +369,7 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
 
 /**
  * @brief      get the current time
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *t points to a time structure
  * @return     status code
  *             - 0 success
@@ -378,7 +378,7 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t)
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_time(ds1307_handle_t *handle, ds1307_time_t *t)
+uint8_t ds1307_get_time(ds1307_handle_t handle, ds1307_time_t *t)
 {
     uint8_t res;
     uint8_t buf[7];
@@ -393,7 +393,7 @@ uint8_t ds1307_get_time(ds1307_handle_t *handle, ds1307_time_t *t)
     }
     if (t == NULL)                                                                        /* check time */
     {
-        handle->debug_print("ds1307: time is null.\n");                                   /* time is null */
+        handle->debug_print(handle, "ds1307: time is null.\n");                           /* time is null */
         
         return 2;                                                                         /* return error */
     }
@@ -402,7 +402,7 @@ uint8_t ds1307_get_time(ds1307_handle_t *handle, ds1307_time_t *t)
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_SECOND, (uint8_t *)buf, 7);       /* multiple_read */
     if (res != 0)                                                                         /* check result */
     {
-        handle->debug_print("ds1307: multiple read failed.\n");                           /* multiple read failed */
+        handle->debug_print(handle, "ds1307: multiple read failed.\n");                   /* multiple read failed */
         
         return 1;                                                                         /* return error */
     }
@@ -428,7 +428,7 @@ uint8_t ds1307_get_time(ds1307_handle_t *handle, ds1307_time_t *t)
 
 /**
  * @brief     enable or disable the oscillator
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] enable is a bool value
  * @return    status code
  *            - 0 success
@@ -437,7 +437,7 @@ uint8_t ds1307_get_time(ds1307_handle_t *handle, ds1307_time_t *t)
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_oscillator(ds1307_handle_t *handle, ds1307_bool_t enable)
+uint8_t ds1307_set_oscillator(ds1307_handle_t handle, ds1307_bool_t enable)
 {
     uint8_t res;
     uint8_t prev;
@@ -454,7 +454,7 @@ uint8_t ds1307_set_oscillator(ds1307_handle_t *handle, ds1307_bool_t enable)
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_SECOND, &prev, 1);        /* read second */
     if (res != 0)                                                                 /* check result */
     {
-        handle->debug_print("ds1307: read second failed.\n");                     /* read second failed */
+        handle->debug_print(handle, "ds1307: read second failed.\n");             /* read second failed */
         
         return 1;                                                                 /* return error */
     }
@@ -463,7 +463,7 @@ uint8_t ds1307_set_oscillator(ds1307_handle_t *handle, ds1307_bool_t enable)
     res = a_ds1307_iic_write(handle, DS1307_REG_SECOND, prev);                    /* write second */
     if (res != 0)                                                                 /* check result */
     {
-        handle->debug_print("ds1307: write second failed.\n");                    /* write second failed */
+        handle->debug_print(handle, "ds1307: write second failed.\n");            /* write second failed */
         
         return 1;                                                                 /* return error */
     }
@@ -473,7 +473,7 @@ uint8_t ds1307_set_oscillator(ds1307_handle_t *handle, ds1307_bool_t enable)
 
 /**
  * @brief      get the chip oscillator status
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *enable points to a bool value buffer
  * @return     status code
  *             - 0 success
@@ -482,7 +482,7 @@ uint8_t ds1307_set_oscillator(ds1307_handle_t *handle, ds1307_bool_t enable)
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_oscillator(ds1307_handle_t *handle, ds1307_bool_t *enable)
+uint8_t ds1307_get_oscillator(ds1307_handle_t handle, ds1307_bool_t *enable)
 {
     uint8_t res;
     uint8_t prev;
@@ -499,7 +499,7 @@ uint8_t ds1307_get_oscillator(ds1307_handle_t *handle, ds1307_bool_t *enable)
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_SECOND, (uint8_t *)&prev, 1);        /* multiple read */
     if (res != 0)                                                                            /* check result */
     {
-        handle->debug_print("ds1307: read second failed.\n");                                /* read second failed */
+        handle->debug_print(handle, "ds1307: read second failed.\n");                        /* read second failed */
         
         return 1;                                                                            /* return error */
     }
@@ -519,7 +519,7 @@ uint8_t ds1307_get_oscillator(ds1307_handle_t *handle, ds1307_bool_t *enable)
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_output_level(ds1307_handle_t *handle, ds1307_output_level_t level)
+uint8_t ds1307_set_output_level(ds1307_handle_t handle, ds1307_output_level_t level)
 {
     uint8_t res;
     uint8_t prev;
@@ -536,7 +536,7 @@ uint8_t ds1307_set_output_level(ds1307_handle_t *handle, ds1307_output_level_t l
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_CONTROL, &prev, 1);        /* read control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: read control failed.\n");                     /* read control failed */
+        handle->debug_print(handle, "ds1307: read control failed.\n");             /* read control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -545,7 +545,7 @@ uint8_t ds1307_set_output_level(ds1307_handle_t *handle, ds1307_output_level_t l
     res = a_ds1307_iic_write(handle, DS1307_REG_CONTROL, prev);                    /* write control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: write control failed.\n");                    /* write control failed */
+        handle->debug_print(handle, "ds1307: write control failed.\n");            /* write control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -555,7 +555,7 @@ uint8_t ds1307_set_output_level(ds1307_handle_t *handle, ds1307_output_level_t l
 
 /**
  * @brief      get the output level
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *level points to an output level buffer
  * @return     status code
  *             - 0 success
@@ -564,7 +564,7 @@ uint8_t ds1307_set_output_level(ds1307_handle_t *handle, ds1307_output_level_t l
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_output_level(ds1307_handle_t *handle, ds1307_output_level_t *level)
+uint8_t ds1307_get_output_level(ds1307_handle_t handle, ds1307_output_level_t *level)
 {
     uint8_t res;
     uint8_t prev;
@@ -581,7 +581,7 @@ uint8_t ds1307_get_output_level(ds1307_handle_t *handle, ds1307_output_level_t *
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_CONTROL, &prev, 1);        /* read control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: read control failed.\n");                     /* read control failed */
+        handle->debug_print(handle, "ds1307: read control failed.\n");             /* read control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -592,7 +592,7 @@ uint8_t ds1307_get_output_level(ds1307_handle_t *handle, ds1307_output_level_t *
 
 /**
  * @brief     set the output mode
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] mode is the output mode
  * @return    status code
  *            - 0 success
@@ -601,7 +601,7 @@ uint8_t ds1307_get_output_level(ds1307_handle_t *handle, ds1307_output_level_t *
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t mode)
+uint8_t ds1307_set_output_mode(ds1307_handle_t handle, ds1307_output_mode_t mode)
 {
     uint8_t res;
     uint8_t prev;
@@ -618,7 +618,7 @@ uint8_t ds1307_set_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t mod
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_CONTROL, &prev, 1);        /* read control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: read control failed.\n");                     /* read control failed */
+        handle->debug_print(handle, "ds1307: read control failed.\n");             /* read control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -627,7 +627,7 @@ uint8_t ds1307_set_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t mod
     res = a_ds1307_iic_write(handle, DS1307_REG_CONTROL, prev);                    /* write control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: write control failed.\n");                    /* write control failed */
+        handle->debug_print(handle, "ds1307: write control failed.\n");            /* write control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -637,7 +637,7 @@ uint8_t ds1307_set_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t mod
 
 /**
  * @brief      get the output mode
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *mode points to an output mode buffer
  * @return     status code
  *             - 0 success
@@ -646,7 +646,7 @@ uint8_t ds1307_set_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t mod
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t *mode)
+uint8_t ds1307_get_output_mode(ds1307_handle_t handle, ds1307_output_mode_t *mode)
 {
     uint8_t res;
     uint8_t prev;
@@ -663,7 +663,7 @@ uint8_t ds1307_get_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t *mo
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_CONTROL, &prev, 1);        /* read control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: read control failed.\n");                     /* read control failed */
+        handle->debug_print(handle, "ds1307: read control failed.\n");             /* read control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -674,7 +674,7 @@ uint8_t ds1307_get_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t *mo
 
 /**
  * @brief     set the square wave frequency
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] freq is the square wave frequency
  * @return    status code
  *            - 0 success
@@ -683,7 +683,7 @@ uint8_t ds1307_get_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t *mo
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_wave_frequency_t freq)
+uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t handle, ds1307_square_wave_frequency_t freq)
 {
     uint8_t res;
     uint8_t prev;
@@ -700,7 +700,7 @@ uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_CONTROL, &prev, 1);        /* read control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: read control failed.\n");                     /* read control failed */
+        handle->debug_print(handle, "ds1307: read control failed.\n");             /* read control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -709,7 +709,7 @@ uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
     res = a_ds1307_iic_write(handle, DS1307_REG_CONTROL, prev);                    /* write control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: write control failed.\n");                    /* write control failed */
+        handle->debug_print(handle, "ds1307: write control failed.\n");            /* write control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -719,7 +719,7 @@ uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
 
 /**
  * @brief      get the square wave frequency
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *freq points to a square wave frequency buffer
  * @return     status code
  *             - 0 success
@@ -728,7 +728,7 @@ uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_wave_frequency_t *freq)
+uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t handle, ds1307_square_wave_frequency_t *freq)
 {
     uint8_t res;
     uint8_t prev;
@@ -745,7 +745,7 @@ uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
     res = a_ds1307_iic_multiple_read(handle, DS1307_REG_CONTROL, &prev, 1);        /* read control */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: read control failed.\n");                     /* read control failed */
+        handle->debug_print(handle, "ds1307: read control failed.\n");             /* read control failed */
         
         return 1;                                                                  /* return error */
     }
@@ -756,7 +756,7 @@ uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
 
 /**
  * @brief      read ram
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[in]  addr is the ram address
  * @param[out] *buf points to a data buffer
  * @param[in]  len is the buffer length
@@ -769,7 +769,7 @@ uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
  *             - 5 len is invalid
  * @note       none
  */
-uint8_t ds1307_read_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uint8_t len)
+uint8_t ds1307_read_ram(ds1307_handle_t handle, uint8_t addr, uint8_t *buf, uint8_t len)
 {
     uint8_t res;
     
@@ -783,13 +783,13 @@ uint8_t ds1307_read_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uin
     }
     if (addr > 55)                                                                 /* check addr */
     {
-        handle->debug_print("ds1307: addr > 55.\n");                               /* addr > 55 */
+        handle->debug_print(handle, "ds1307: addr > 55.\n");                       /* addr > 55 */
         
         return 4;                                                                  /* return error */
     }
     if (addr + len - 1 > 55)                                                       /* check len */
     {
-        handle->debug_print("ds1307: len is invalid.\n");                          /* len is invalid */
+        handle->debug_print(handle, "ds1307: len is invalid.\n");                  /* len is invalid */
         
         return 5;                                                                  /* return error */
     }
@@ -798,7 +798,7 @@ uint8_t ds1307_read_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uin
                                      buf, len);                                    /* read ram */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: read ram failed.\n");                         /* read ram failed */
+        handle->debug_print(handle, "ds1307: read ram failed.\n");                 /* read ram failed */
         
         return 1;                                                                  /* return error */
     }
@@ -808,7 +808,7 @@ uint8_t ds1307_read_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uin
 
 /**
  * @brief     write ram
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] addr is the ram address
  * @param[in] *buf points to a data buffer
  * @param[in] len is the buffer length
@@ -821,7 +821,7 @@ uint8_t ds1307_read_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uin
  *            - 5 len is invalid
  * @note      none
  */
-uint8_t ds1307_write_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uint8_t len)
+uint8_t ds1307_write_ram(ds1307_handle_t handle, uint8_t addr, uint8_t *buf, uint8_t len)
 {
     uint8_t res;
     
@@ -835,13 +835,13 @@ uint8_t ds1307_write_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, ui
     }
     if (addr > 55)                                                                 /* check addr */
     {
-        handle->debug_print("ds1307: addr > 55.\n");                               /* addr > 55 */
+        handle->debug_print(handle, "ds1307: addr > 55.\n");                       /* addr > 55 */
         
         return 4;                                                                  /* return error */
     }
     if (addr + len - 1 > 55)                                                       /* check len */
     {
-        handle->debug_print("ds1307: len is invalid.\n");                          /* len is invalid */
+        handle->debug_print(handle, "ds1307: len is invalid.\n");                  /* len is invalid */
         
         return 5;                                                                  /* return error */
     }
@@ -850,7 +850,7 @@ uint8_t ds1307_write_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, ui
                                       buf, len);                                   /* write ram */
     if (res != 0)                                                                  /* check result */
     {
-        handle->debug_print("ds1307: write ram failed.\n");                        /* write ram failed */
+        handle->debug_print(handle, "ds1307: write ram failed.\n");                /* write ram failed */
         
         return 1;                                                                  /* return error */
     }
@@ -860,7 +860,7 @@ uint8_t ds1307_write_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, ui
 
 /**
  * @brief     initialize the chip
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @return    status code
  *            - 0 success
  *            - 1 iic initialization failed
@@ -868,61 +868,61 @@ uint8_t ds1307_write_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, ui
  *            - 3 linked functions is NULL
  * @note      none
  */
-uint8_t ds1307_init(ds1307_handle_t *handle)
+uint8_t ds1307_init(ds1307_handle_t handle)
 {
-    if (handle == NULL)                                              /* check handle */
+    if (handle == NULL)                                                        /* check handle */
     {
-        return 2;                                                    /* return error */
+        return 2;                                                              /* return error */
     }
-    if (handle->debug_print == NULL)                                 /* check debug_print */
+    if (handle->debug_print == NULL)                                           /* check debug_print */
     {
-        return 3;                                                    /* return error */
+        return 3;                                                              /* return error */
     }
-    if (handle->iic_init == NULL)                                    /* check iic_init */
+    if (handle->iic_init == NULL)                                              /* check iic_init */
     {
-        handle->debug_print("ds1307: iic_init is null.\n");          /* iic_init is null */
+        handle->debug_print(handle, "ds1307: iic_init is null.\n");            /* iic_init is null */
        
-        return 3;                                                    /* return error */
+        return 3;                                                              /* return error */
     }
-    if (handle->iic_deinit == NULL)                                  /* check iic_deinit */
+    if (handle->iic_deinit == NULL)                                            /* check iic_deinit */
     {
-        handle->debug_print("ds1307: iic_deinit is null.\n");        /* iic_deinit is null */
+        handle->debug_print(handle, "ds1307: iic_deinit is null.\n");          /* iic_deinit is null */
        
-        return 3;                                                    /* return error */
+        return 3;                                                              /* return error */
     }
-    if (handle->iic_write == NULL)                                   /* check iic_write */
+    if (handle->iic_write == NULL)                                             /* check iic_write */
     {
-        handle->debug_print("ds1307: iic_write is null.\n");         /* iic_write is null */
+        handle->debug_print(handle, "ds1307: iic_write is null.\n");           /* iic_write is null */
        
-        return 3;                                                    /* return error */
+        return 3;                                                              /* return error */
     }
-    if (handle->iic_read == NULL)                                    /* check iic_read */
+    if (handle->iic_read == NULL)                                              /* check iic_read */
     {
-        handle->debug_print("ds1307: iic_read is null.\n");          /* iic_read is null */
+        handle->debug_print(handle, "ds1307: iic_read is null.\n");            /* iic_read is null */
        
-        return 3;                                                    /* return error */
+        return 3;                                                              /* return error */
     }
-    if (handle->delay_ms == NULL)                                    /* check delay_ms */
+    if (handle->delay_ms == NULL)                                              /* check delay_ms */
     {
-        handle->debug_print("ds1307: delay_ms is null.\n");          /* delay_ms is null */
+        handle->debug_print(handle, "ds1307: delay_ms is null.\n");            /* delay_ms is null */
        
-        return 3;                                                    /* return error */
+        return 3;                                                              /* return error */
     }
     
-    if (handle->iic_init() != 0)                                     /* iic init */
+    if (handle->iic_init(handle) != 0)                                         /* iic init */
     {
-        handle->debug_print("ds1307: iic init failed.\n");           /* iic init failed */
+        handle->debug_print(handle, "ds1307: iic init failed.\n");             /* iic init failed */
        
-        return 1;                                                    /* return error */
+        return 1;                                                              /* return error */
     }
-    handle->inited = 1;                                              /* flag finish initialization */
+    handle->inited = 1;                                                        /* flag finish initialization */
     
-    return 0;                                                        /* success return 0 */
+    return 0;                                                                  /* success return 0 */
 }
 
 /**
  * @brief     close the chip
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @return    status code
  *            - 0 success
  *            - 1 iic deinit failed
@@ -930,31 +930,31 @@ uint8_t ds1307_init(ds1307_handle_t *handle)
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_deinit(ds1307_handle_t *handle)
+uint8_t ds1307_deinit(ds1307_handle_t handle)
 {
-    if (handle == NULL)                                             /* check handle */
+    if (handle == NULL)                                                        /* check handle */
     {
-        return 2;                                                   /* return error */
+        return 2;                                                              /* return error */
     }
-    if (handle->inited != 1)                                        /* check handle initialization */
+    if (handle->inited != 1)                                                   /* check handle initialization */
     {
-        return 3;                                                   /* return error */
+        return 3;                                                              /* return error */
     }
     
-    if (handle->iic_deinit() != 0)                                  /* iic deinit */
+    if (handle->iic_deinit(handle) != 0)                                       /* iic deinit */
     {
-        handle->debug_print("ds1307: iic deinit failed.\n");        /* iic deinit failed */
+        handle->debug_print(handle, "ds1307: iic deinit failed.\n");           /* iic deinit failed */
        
-        return 1;                                                   /* return error */
+        return 1;                                                              /* return error */
     }
-    handle->inited = 0;                                             /* flag close */
+        handle->inited = 0;                                                    /* flag close */
     
-    return 0;                                                       /* success return 0 */
+    return 0;                                                                  /* success return 0 */
 }
 
 /**
  * @brief     set the chip register
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] reg is the iic register address
  * @param[in] *buf points to a data buffer
  * @param[in] len is the data buffer length
@@ -965,30 +965,30 @@ uint8_t ds1307_deinit(ds1307_handle_t *handle)
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_reg(ds1307_handle_t *handle, uint8_t reg, uint8_t *buf, uint16_t len)
+uint8_t ds1307_set_reg(ds1307_handle_t handle, uint8_t reg, uint8_t *buf, uint16_t len)
 {
-    if (handle == NULL)                                               /* check handle */
+    if (handle == NULL)                                                 /* check handle */
     {
-        return 2;                                                     /* return error */
+        return 2;                                                       /* return error */
     }
-    if (handle->inited != 1)                                          /* check handle initialization */
+    if (handle->inited != 1)                                            /* check handle initialization */
     {
-        return 3;                                                     /* return error */
+        return 3;                                                       /* return error */
     }
     
-    if (handle->iic_write(DS1307_ADDRESS, reg, buf, len) != 0)        /* write data */
+    if (handle->iic_write(handle, DS1307_ADDRESS, reg, buf, len) != 0)  /* write data */
     {
-        return 1;                                                     /* return error */
+        return 1;                                                       /* return error */
     }
     else
     {
-        return 0;                                                     /* success return 0 */
+        return 0;                                                       /* success return 0 */
     }
 }
 
 /**
  * @brief      get the chip register
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[in]  reg is the iic register address
  * @param[out] *buf points to a data buffer
  * @param[in]  len is the data buffer length
@@ -999,24 +999,24 @@ uint8_t ds1307_set_reg(ds1307_handle_t *handle, uint8_t reg, uint8_t *buf, uint1
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_reg(ds1307_handle_t *handle, uint8_t reg, uint8_t *buf, uint16_t len)
+uint8_t ds1307_get_reg(ds1307_handle_t handle, uint8_t reg, uint8_t *buf, uint16_t len)
 {
-    if (handle == NULL)                                              /* check handle */
+    if (handle == NULL)                                                     /* check handle */
     {
-        return 2;                                                    /* return error */
+        return 2;                                                           /* return error */
     }
-    if (handle->inited != 1)                                         /* check handle initialization */
+    if (handle->inited != 1)                                                /* check handle initialization */
     {
-        return 3;                                                    /* return error */
+        return 3;                                                           /* return error */
     }
     
-    if (handle->iic_read(DS1307_ADDRESS, reg, buf, len) != 0)        /* read data */
+    if (handle->iic_read(handle, DS1307_ADDRESS, reg, buf, len) != 0)       /* read data */
     {
-        return 1;                                                    /* return error */
+        return 1;                                                           /* return error */
     }
     else
     {
-        return 0;                                                    /* success return 0 */
+        return 0;                                                           /* success return 0 */
     }
 }
 

--- a/src/driver_ds1307.h
+++ b/src/driver_ds1307.h
@@ -129,18 +129,28 @@ typedef struct ds1307_time_s
 } ds1307_time_t;
 
 /**
- * @brief ds1307 handle structure definition
+ * @brief ds1307 structure type definition
  */
-typedef struct ds1307_handle_s
+typedef struct ds1307_s ds1307_t;
+
+/**
+ * @brief ds1307 handle type definition
+ */
+typedef ds1307_t *ds1307_handle_t;
+
+/**
+ * @brief ds1307 structure definition
+ */
+struct ds1307_s
 {
-    uint8_t (*iic_init)(void);                                                          /**< point to an iic_init function address */
-    uint8_t (*iic_deinit)(void);                                                        /**< point to an iic_deinit function address */
-    uint8_t (*iic_write)(uint8_t addr, uint8_t reg, uint8_t *buf, uint16_t len);        /**< point to an iic_write function address */
-    uint8_t (*iic_read)(uint8_t addr, uint8_t reg, uint8_t *buf, uint16_t len);         /**< point to an iic_read function address */
-    void (*debug_print)(const char *const fmt, ...);                                    /**< point to a debug_print function address */
-    void (*delay_ms)(uint32_t ms);                                                      /**< point to a delay_ms function address */
-    uint8_t inited;                                                                     /**< inited flag */
-} ds1307_handle_t;
+    uint8_t (*iic_init)(ds1307_handle_t handle);                                                            /**< point to an iic_init function address */
+    uint8_t (*iic_deinit)(ds1307_handle_t handle);                                                          /**< point to an iic_deinit function address */
+    uint8_t (*iic_write)(ds1307_handle_t handle, uint8_t addr, uint8_t reg, uint8_t *buf, uint16_t len);    /**< point to an iic_write function address */
+    uint8_t (*iic_read)(ds1307_handle_t handle, uint8_t addr, uint8_t reg, uint8_t *buf, uint16_t len);     /**< point to an iic_read function address */
+    void (*debug_print)(ds1307_handle_t handle, const char *const fmt, ...);                                /**< point to a debug_print function address */
+    void (*delay_ms)(ds1307_handle_t handle, uint32_t ms);                                                  /**< point to a delay_ms function address */
+    uint8_t inited;                                                                                         /**< inited flag */
+};
 
 /**
  * @brief ds1307 information structure definition
@@ -248,7 +258,7 @@ uint8_t ds1307_info(ds1307_info_t *info);
 
 /**
  * @brief     initialize the chip
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @return    status code
  *            - 0 success
  *            - 1 iic initialization failed
@@ -256,11 +266,11 @@ uint8_t ds1307_info(ds1307_info_t *info);
  *            - 3 linked functions is NULL
  * @note      none
  */
-uint8_t ds1307_init(ds1307_handle_t *handle);
+uint8_t ds1307_init(ds1307_handle_t handle);
 
 /**
  * @brief     close the chip
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @return    status code
  *            - 0 success
  *            - 1 iic deinit failed
@@ -268,11 +278,11 @@ uint8_t ds1307_init(ds1307_handle_t *handle);
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_deinit(ds1307_handle_t *handle);
+uint8_t ds1307_deinit(ds1307_handle_t handle);
 
 /**
  * @brief     set the current time
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] *t points to a time structure
  * @return    status code
  *            - 0 success
@@ -282,11 +292,11 @@ uint8_t ds1307_deinit(ds1307_handle_t *handle);
  *            - 4 time is invalid
  * @note      none
  */
-uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t);
+uint8_t ds1307_set_time(ds1307_handle_t handle, ds1307_time_t *t);
 
 /**
  * @brief      get the current time
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *t points to a time structure
  * @return     status code
  *             - 0 success
@@ -295,11 +305,11 @@ uint8_t ds1307_set_time(ds1307_handle_t *handle, ds1307_time_t *t);
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_time(ds1307_handle_t *handle, ds1307_time_t *t);
+uint8_t ds1307_get_time(ds1307_handle_t handle, ds1307_time_t *t);
 
 /**
  * @brief      read ram
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[in]  addr is the ram address
  * @param[out] *buf points to a data buffer
  * @param[in]  len is the buffer length
@@ -312,11 +322,11 @@ uint8_t ds1307_get_time(ds1307_handle_t *handle, ds1307_time_t *t);
  *             - 5 len is invalid
  * @note       none
  */
-uint8_t ds1307_read_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uint8_t len);
+uint8_t ds1307_read_ram(ds1307_handle_t handle, uint8_t addr, uint8_t *buf, uint8_t len);
 
 /**
  * @brief     write ram
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] addr is the ram address
  * @param[in] *buf points to a data buffer
  * @param[in] len is the buffer length
@@ -329,11 +339,11 @@ uint8_t ds1307_read_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uin
  *            - 5 len is invalid
  * @note      none
  */
-uint8_t ds1307_write_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, uint8_t len);
+uint8_t ds1307_write_ram(ds1307_handle_t handle, uint8_t addr, uint8_t *buf, uint8_t len);
 
 /**
  * @brief     enable or disable the oscillator
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] enable is a bool value
  * @return    status code
  *            - 0 success
@@ -342,11 +352,11 @@ uint8_t ds1307_write_ram(ds1307_handle_t *handle, uint8_t addr, uint8_t *buf, ui
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_oscillator(ds1307_handle_t *handle, ds1307_bool_t enable);
+uint8_t ds1307_set_oscillator(ds1307_handle_t handle, ds1307_bool_t enable);
 
 /**
  * @brief      get the chip oscillator status
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *enable points to a bool value buffer
  * @return     status code
  *             - 0 success
@@ -355,11 +365,11 @@ uint8_t ds1307_set_oscillator(ds1307_handle_t *handle, ds1307_bool_t enable);
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_oscillator(ds1307_handle_t *handle, ds1307_bool_t *enable);
+uint8_t ds1307_get_oscillator(ds1307_handle_t handle, ds1307_bool_t *enable);
 
 /**
  * @brief     set the output level
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] level is the output level
  * @return    status code
  *            - 0 success
@@ -368,11 +378,11 @@ uint8_t ds1307_get_oscillator(ds1307_handle_t *handle, ds1307_bool_t *enable);
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_output_level(ds1307_handle_t *handle, ds1307_output_level_t level);
+uint8_t ds1307_set_output_level(ds1307_handle_t handle, ds1307_output_level_t level);
 
 /**
  * @brief      get the output level
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *level points to an output level buffer
  * @return     status code
  *             - 0 success
@@ -381,11 +391,11 @@ uint8_t ds1307_set_output_level(ds1307_handle_t *handle, ds1307_output_level_t l
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_output_level(ds1307_handle_t *handle, ds1307_output_level_t *level);
+uint8_t ds1307_get_output_level(ds1307_handle_t handle, ds1307_output_level_t *level);
 
 /**
  * @brief     set the output mode
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] mode is the output mode
  * @return    status code
  *            - 0 success
@@ -394,11 +404,11 @@ uint8_t ds1307_get_output_level(ds1307_handle_t *handle, ds1307_output_level_t *
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t mode);
+uint8_t ds1307_set_output_mode(ds1307_handle_t handle, ds1307_output_mode_t mode);
 
 /**
  * @brief      get the output mode
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *mode points to an output mode buffer
  * @return     status code
  *             - 0 success
@@ -407,11 +417,11 @@ uint8_t ds1307_set_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t mod
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t *mode);
+uint8_t ds1307_get_output_mode(ds1307_handle_t handle, ds1307_output_mode_t *mode);
 
 /**
  * @brief     set the square wave frequency
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] freq is the square wave frequency
  * @return    status code
  *            - 0 success
@@ -420,11 +430,11 @@ uint8_t ds1307_get_output_mode(ds1307_handle_t *handle, ds1307_output_mode_t *mo
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_wave_frequency_t freq);
+uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t handle, ds1307_square_wave_frequency_t freq);
 
 /**
  * @brief      get the square wave frequency
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[out] *freq points to a square wave frequency buffer
  * @return     status code
  *             - 0 success
@@ -433,7 +443,7 @@ uint8_t ds1307_set_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_wave_frequency_t *freq);
+uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t handle, ds1307_square_wave_frequency_t *freq);
 
 /**
  * @}
@@ -448,7 +458,7 @@ uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
 
 /**
  * @brief     set the chip register
- * @param[in] *handle points to a ds1307 handle structure
+ * @param[in] handle points to a ds1307 handle structure
  * @param[in] reg is the iic register address
  * @param[in] *buf points to a data buffer
  * @param[in] len is the data buffer length
@@ -459,11 +469,11 @@ uint8_t ds1307_get_square_wave_frequency(ds1307_handle_t *handle, ds1307_square_
  *            - 3 handle is not initialized
  * @note      none
  */
-uint8_t ds1307_set_reg(ds1307_handle_t *handle, uint8_t reg, uint8_t *buf, uint16_t len);
+uint8_t ds1307_set_reg(ds1307_handle_t handle, uint8_t reg, uint8_t *buf, uint16_t len);
 
 /**
  * @brief      get the chip register
- * @param[in]  *handle points to a ds1307 handle structure
+ * @param[in]  handle points to a ds1307 handle structure
  * @param[in]  reg is the iic register address
  * @param[out] *buf points to a data buffer
  * @param[in]  len is the data buffer length
@@ -474,7 +484,7 @@ uint8_t ds1307_set_reg(ds1307_handle_t *handle, uint8_t reg, uint8_t *buf, uint1
  *             - 3 handle is not initialized
  * @note       none
  */
-uint8_t ds1307_get_reg(ds1307_handle_t *handle, uint8_t reg, uint8_t *buf, uint16_t len);
+uint8_t ds1307_get_reg(ds1307_handle_t handle, uint8_t reg, uint8_t *buf, uint16_t len);
 
 /**
  * @}


### PR DESCRIPTION
Hi, please take a look at my suggestion for improving the library

Providing `ds1307_handle_t` is necessary for things like this: 

```
typedef struct {
    ds1307_t base;
    esp_ds1307_config_t config;
    i2c_master_dev_handle_t i2c_handle;
} esp_ds1307_t;

esp_ds1307_t *ds1307 = __containerof(handle, esp_ds1307_t, base);
```

This will allow you to get, for example, an i2c handler from the structure.

The changes do not cover your entire repository, they only provide minimal functionality for the driver itself. If you are interested, I can continue moving in this direction

